### PR TITLE
Fix "Undefined variable" error

### DIFF
--- a/Fluent/includes/FluentTemplate.php
+++ b/Fluent/includes/FluentTemplate.php
@@ -264,6 +264,7 @@ class FluentTemplate extends BaseTemplate {
 	 */
 	protected function getPageLinks() {
 		$leftNav = "";
+		$rightNav = "";
 		// Namespaces: links for 'content' and 'talk' for namespaces with talkpages. Otherwise is just the content.
 		// Usually rendered as tabs on the top of the page.
 		if (count($this->data['content_navigation']['namespaces']) > 0) {


### PR DESCRIPTION
Fix for https://github.com/immewnity/mediawiki-fluent/issues/6
This is simply because $rightNav is uninitialized.