### PR TITLE
Remove Skin::getSkinStylePath() for 1.39

### DIFF
--- a/Fluent/includes/FluentTemplate.php
+++ b/Fluent/includes/FluentTemplate.php
@@ -306,11 +306,12 @@ class FluentTemplate extends BaseTemplate {
 	 * Generates URL for the user's Gravatar, or defaults to a generic face if no Gravatar
 	 * @return string html
 	 */
-	protected function getGravatarUrl() {
-		$genericFace = $this->config->get( 'CanonicalServer' ) . $this->getSkin()->getSkinStylePath('resources/default-user.png');
-		$gravatarUrl = 'https://www.gravatar.com/avatar/' . md5( strtolower( trim( $this->getSkin()->getUser()->getEmail() ) ) ) . '?d=' . urlencode ( $genericFace ) . '&s=' . 100;
-		return $gravatarUrl;
-	}
+    protected function getGravatarUrl() {
+        $skin = $this->getSkin();
+        $genericFace = $this->config->get('CanonicalServer') . $skin->getConfig()->get('StylePath') . 'resources/default-user.png';
+        $gravatarUrl = 'https://www.gravatar.com/avatar/' . md5(strtolower(trim($this->getSkin()->getUser()->getEmail()))) . '?d=' . urlencode($genericFace) . '&s=' . 100;
+        return $gravatarUrl;
+    }
 
 	/**
 	 * Generates user tools menu


### PR DESCRIPTION
Skin::getSkinStylePath has been depreciated for a while and was removed in 1.39, this is the issue with the skin. I've removed it and this has fixed the issue for MW 1.39+; not sure about backwards compatability.